### PR TITLE
Drop GHA Docker Caching

### DIFF
--- a/.github/workflows/update_docker.yml
+++ b/.github/workflows/update_docker.yml
@@ -25,20 +25,12 @@ jobs:
         include:
           - os: "ubuntu"
             release: "jammy"
-            cache-from: "type=gha,scope=docker_build_jammy" # all-automatic GitHub Actions caching
-            cache-to: "type=gha,scope=docker_build_jammy,mode=max" # all-automatic GitHub Actions caching, max mode
           - os: "debian"
             release: "bookworm"
-            cache-from: "" # no caching
-            cache-to: "" # no caching
 #          - os: "debian"
 #            release: "sid"
-#           cache-from: "" # no caching
-#            cache-to: "" # no caching
           - os: "ubuntu"
             release: "noble"
-            cache-from: "type=gha,scope=docker_build_noble" # all-automatic GitHub Actions caching
-            cache-to: "type=gha,scope=docker_build_noble,mode=max" # all-automatic GitHub Actions caching, max mode
     name: "${{ matrix.release }} (${{ matrix.os }})"
     env:
       DOCKERFILE_OS: "${{ matrix.os }}"
@@ -108,8 +100,6 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
-          cache-from: "${{ matrix.cache-from }}"
-          cache-to: "${{ matrix.cache-to }}"
           tags: ghcr.io/${{ github.repository }}:armbian-${{env.DOCKERFILE_OS}}-${{env.DOCKERFILE_RELEASE}}-latest
 
       - name: sleep a random amount of seconds, up to 60, if build/push failed, before trying again
@@ -138,8 +128,6 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
-          #cache-from: "${{ matrix.cache-from }}" # do NOT reload cache when retrying
-          cache-to: "${{ matrix.cache-to }}" # but do save cache
           tags: ghcr.io/${{ github.repository }}:armbian-${{env.DOCKERFILE_OS}}-${{env.DOCKERFILE_RELEASE}}-latest
 
 


### PR DESCRIPTION
Seems the cache is being hit "too much" and we're shipping a broken version of `rsync` -- See https://github.com/armbian/build/issues/7830

I will send a bigger change later making use of the new arm64 runners (so arm64 builds are not so slow - the main reason the cache was added in the first place)