### PR TITLE
Add Docker Images for repo handling workflow

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,306 @@
+name: Build Repository Update Docker Images
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  REGISTRY: ghcr.io/${{ github.repository_owner }}
+
+jobs:
+  setup-matrix:
+    name: "Generate build matrix"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+      images: ${{ steps.generate-matrix.outputs.images }}
+    steps:
+      - name: Checkout Armbian build framework
+        uses: actions/checkout@v4
+        with:
+          repository: armbian/build
+          ref: main
+          path: armbian-build
+
+      - name: Generate matrix from distributions
+        id: generate-matrix
+        run: |
+          MATRIX="{\"include\":["
+          IMAGES=""
+
+          # Process each distribution
+          for dist_file in armbian-build/config/distributions/*/support; do
+            [ -f "$dist_file" ] || continue
+
+            # Check if distribution is marked as "supported" (not "eos" or unsupported)
+            if ! grep -q "supported" "$dist_file"; then
+              echo "::debug::Skipping $(basename $(dirname $dist_file)) - not marked as supported"
+              continue
+            fi
+
+            dist_dir=$(dirname "$dist_file")
+            release=$(basename "$dist_dir")
+
+            # Get distribution name and family
+            dist_name_file="$dist_dir/name"
+            if [ ! -f "$dist_name_file" ]; then
+              echo "::warning::No name file for $release, skipping"
+              continue
+            fi
+
+            dist_name=$(cat "$dist_name_file" | head -n1 | tr -d ' \n')
+
+            # Determine base image based on distribution name
+            # Format: "Ubuntu noble 24.04", "Debian 12 Bookworm", "Ubuntu resolute 26.04"
+            case "$dist_name" in
+              [Dd]ebian*)
+                base_image="debian:$release"
+                ;;
+              [Uu]buntu*)
+                base_image="ubuntu:$release"
+                ;;
+              *)
+                echo "::warning::Unknown distribution family $dist_name for $release, skipping"
+                continue
+                ;;
+            esac
+
+            # Get architectures file
+            arch_file="$dist_dir/architectures"
+            if [ ! -f "$arch_file" ]; then
+              echo "::warning::No architectures file for $release, skipping"
+              continue
+            fi
+
+            # Read architectures (comma-separated on one line or one per line)
+            arch_list=$(cat "$arch_file" | tr -d ' \n' | tr ',' ' ')
+            for arch in $arch_list; do
+              # Skip comments and empty lines
+              [[ "$arch" =~ ^#.*$ ]] && continue
+              [ -z "$arch" ] && continue
+
+              # Map Armbian architecture to Docker platform
+              case "$arch" in
+                amd64)
+                  docker_platform="linux/amd64"
+                  ;;
+                arm64)
+                  docker_platform="linux/arm64"
+                  ;;
+                armhf)
+                  docker_platform="linux/arm/v7"
+                  ;;
+                riscv64)
+                  docker_platform="linux/riscv64"
+                  ;;
+                *)
+                  echo "::warning::Unknown architecture $arch, skipping"
+                  continue
+                  ;;
+              esac
+
+              # Add to matrix
+              if [ -n "$MATRIX_CONTENT" ]; then
+                MATRIX_CONTENT+=","
+              fi
+
+              MATRIX_CONTENT+="{\"release\":\"$release\",\"arch\":\"$arch\",\"docker_platform\":\"$docker_platform\",\"base_image\":\"$base_image\"}"
+
+              # Add to images list for summary
+              if [ -n "$IMAGES" ]; then
+                IMAGES+=", "
+              fi
+              IMAGES+="$release-$arch"
+            done
+
+          done
+
+          if [ -z "$MATRIX_CONTENT" ]; then
+            echo "::error::No supported distributions found with valid architectures"
+            echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          MATRIX="${MATRIX}${MATRIX_CONTENT}]}"
+
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "images=$IMAGES" >> $GITHUB_OUTPUT
+
+          echo "::notice::Generated matrix for $IMAGES"
+          echo "::debug::$MATRIX"
+
+  build-images:
+    name: "Build ${{ matrix.release }}-${{ matrix.arch }}"
+    needs: setup-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Dockerfile
+        run: |
+          cat > Dockerfile <<'DOCKEREOF'
+          FROM ${{ matrix.base_image }}
+
+          ENV ARCH=${{ matrix.arch }} \
+              DEBIAN_FRONTEND=noninteractive
+
+          # Install essential packages
+          RUN apt-get update && apt-get install -y \
+              wget \
+              gnupg \
+              dirmngr \
+              ca-certificates \
+              unzip \
+              rsync \
+              openssh-client \
+              xz-utils \
+              bzip2 \
+              git \
+              curl \
+              jq \
+              sudo \
+              && rm -rf /var/lib/apt/lists/*
+
+          # Install Aptly from Debian/Ubuntu repositories
+          # (GitHub releases require newer GLIBC than available in older base images)
+          RUN apt-get update && \
+              apt-get install -y aptly && \
+              aptly version && \
+              rm -rf /var/lib/apt/lists/*
+
+          # Install appropriate keyring based on container type
+          RUN if grep -q "debian" /etc/os-release; then \
+                apt-get update && \
+                apt-get install -y debian-keyring && \
+                rm -rf /var/lib/apt/lists/*; \
+              elif grep -q "ubuntu" /etc/os-release; then \
+                apt-get update && \
+                apt-get install -y ubuntu-keyring && \
+                rm -rf /var/lib/apt/lists/*; \
+              fi
+
+          # Install GitHub CLI
+          RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+              dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+              chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+              echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list && \
+              apt-get update && \
+              apt-get install -y gh && \
+              rm -rf /var/lib/apt/lists/*
+
+          # Add Armbian stable repository
+          RUN curl -fsSL http://apt.armbian.com/armbian.key | gpg --dearmor -o /usr/share/keyrings/armbian-archive-keyring.gpg && \
+              chmod go+r /usr/share/keyrings/armbian-archive-keyring.gpg && \
+              echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/armbian-archive-keyring.gpg] http://apt.armbian.com bookworm main" > /etc/apt/sources.list.d/armbian.list && \
+              apt-get update && \
+              rm -rf /var/lib/apt/lists/*
+
+          WORKDIR /workspace
+          CMD ["/bin/bash"]
+          DOCKEREOF
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.docker_platform }}
+          tags: |
+            ${{ env.REGISTRY }}/armbian/repository-update:${{ matrix.release }}-${{ matrix.arch }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          load: false
+
+      - name: Image built
+        run: |
+          echo "::notice::Built armbian/repository-update:${{ matrix.release }}-${{ matrix.arch }}"
+          echo "::notice::Pushed to registry"
+
+  summary:
+    name: "Build Summary"
+    needs: [setup-matrix, build-images]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout Armbian build framework
+        uses: actions/checkout@v4
+        with:
+          repository: armbian/build
+          ref: main
+          path: armbian-build
+
+      - name: Generate summary
+        run: |
+          echo '# Docker Images Built' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '| Release | Arch | Image |' >> $GITHUB_STEP_SUMMARY
+          echo '|---------|------|-------|' >> $GITHUB_STEP_SUMMARY
+
+          # Process each distribution
+          for dist_file in armbian-build/config/distributions/*/support; do
+            [ -f "$dist_file" ] || continue
+
+            # Check if distribution is marked as "supported"
+            if ! grep -q "supported" "$dist_file"; then
+              continue
+            fi
+
+            dist_dir=$(dirname "$dist_file")
+            release=$(basename "$dist_dir")
+
+            # Get distribution name and family
+            dist_name_file="$dist_dir/name"
+            if [ ! -f "$dist_name_file" ]; then
+              continue
+            fi
+
+            # Get architectures file
+            arch_file="$dist_dir/architectures"
+            if [ ! -f "$arch_file" ]; then
+              continue
+            fi
+
+            # Read architectures (comma-separated on one line or one per line)
+            arch_list=$(cat "$arch_file" | tr -d ' \n' | tr ',' ' ')
+            for arch in $arch_list; do
+              # Skip comments and empty lines
+              [[ "$arch" =~ ^#.*$ ]] && continue
+              [ -z "$arch" ] && continue
+
+              image="armbian/repository-update:${release}-${arch}"
+              echo "| $release | $arch | $image |" >> $GITHUB_STEP_SUMMARY
+            done
+          done
+
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '✅ Images pushed to GitHub Container Registry' >> $GITHUB_STEP_SUMMARY
+
+  keepalive:
+    if: ${{ github.repository_owner == 'armbian' }}
+    name: Keep Alive
+    needs: summary
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: liskin/gh-workflow-keepalive@v1

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,10 +1,16 @@
-name: Build Repository Update Docker Images
-
+name: Docker Images for repo handling
 on:
   push:
     branches:
       - main
   workflow_dispatch:
+  schedule:
+    - cron: '30 3 * * *' # Scheduled runs every day at 3:30am UTC
+
+permissions:
+  contents: write
+  actions: write
+  packages: write
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,4 +1,4 @@
-name: Docker Images for repo handling
+name: Docker Images For Repo Handling
 on:
   push:
     branches:

--- a/.github/workflows/update_docker.yml
+++ b/.github/workflows/update_docker.yml
@@ -1,4 +1,4 @@
-name: Build Docker Images
+name: Docker Images for Framework
 #
 # Update Docker images we use for building CI
 #


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow to automatically build Docker images for repository handling.

## What it does

- **Dynamically generates build matrix** from Armbian build framework configuration
  - Reads distribution support status from `config/distributions/*/support`
  - Reads distribution names from `config/distributions/*/name`  
  - Reads architectures from `config/distributions/*/architectures`
  - Maps Armbian architectures to Docker platforms (amd64, arm64, armhf, riscv64)

- **Builds multi-architecture Docker images** for all supported distributions
  - Base images: Debian (bookworm, bullseye, etc.) and Ubuntu (noble, jammy, etc.)
  - Platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/riscv64
  - Pushes to GitHub Container Registry (ghcr.io)

- **Images include**:
  - Essential tools: wget, gnupg, dirmngr, ca-certificates, unzip, rsync, openssh-client, xz-utils, bzip2, git, curl, jq, sudo
  - Aptly (from distro repositories for GLIBC compatibility)
  - Distribution keyrings (debian-keyring or ubuntu-keyring)
  - GitHub CLI (gh)
  - Armbian stable repository

- **Features**:
  - GitHub Actions cache for faster builds
  - Summary of all built images
  - Keepalive job for workflow maintenance (armbian org only)

## Image naming

Images are tagged as: `ghcr.io/armbian/repository-update:{release}-{arch}`

Examples:
- `ghcr.io/armbian/repository-update:bookworm-amd64`
- `ghcr.io/armbian/repository-update:noble-arm64`
- `ghcr.io/armbian/repository-update:jammy-armhf`

## Usage

These images are designed for repository management workflows that need:
- Aptly for repository operations
- GitHub CLI for GitHub API interactions
- Armbian repository access
- Multi-architecture support