### PR TITLE
Reverse EOS detection logic and limit architectures

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -41,9 +41,9 @@ jobs:
           for dist_file in armbian-build/config/distributions/*/support; do
             [ -f "$dist_file" ] || continue
 
-            # Check if distribution is marked as "supported" (not "eos" or unsupported)
-            if ! grep -q "supported" "$dist_file"; then
-              echo "::debug::Skipping $(basename $(dirname $dist_file)) - not marked as supported"
+            # Skip distribution if marked as EOS (End of Service)
+            if grep -qi "eos" "$dist_file"; then
+              echo "::debug::Skipping $(basename $(dirname $dist_file)) - marked as EOS"
               continue
             fi
 
@@ -96,11 +96,9 @@ jobs:
                 arm64)
                   docker_platform="linux/arm64"
                   ;;
-                armhf)
-                  docker_platform="linux/arm/v7"
-                  ;;
-                riscv64)
-                  docker_platform="linux/riscv64"
+                armhf|riscv64)
+                  echo "::debug::Skipping $arch - fragile. Will use in the future or drop entirely"
+                  continue
                   ;;
                 *)
                   echo "::warning::Unknown architecture $arch, skipping"
@@ -265,8 +263,8 @@ jobs:
           for dist_file in armbian-build/config/distributions/*/support; do
             [ -f "$dist_file" ] || continue
 
-            # Check if distribution is marked as "supported"
-            if ! grep -q "supported" "$dist_file"; then
+            # Skip distribution if marked as EOS (End of Service)
+            if grep -qi "eos" "$dist_file"; then
               continue
             fi
 


### PR DESCRIPTION
## Summary
- Changed the logic to include all distributions except those marked as EOS (End of Service)
- Previously, only distributions explicitly marked as "supported" were included
- Now, all distributions are included by default, with only EOS distributions being excluded
- Limited Docker builds to amd64 and arm64 only (excluded armhf and riscv64)

## Benefits
- More inclusive approach that reduces maintenance overhead
- New distributions automatically included without needing to update support status
- Only requires marking distributions as EOS when they reach end of life
- Faster builds by focusing on stable architectures (amd64, arm64)

## Test plan
- [x] Verify workflow runs successfully
- [x] Check that EOS distributions are properly excluded
- [x] Confirm non-EOS distributions are included in matrix
- [x] Verify only amd64 and arm64 images are built