### PR TITLE
Fix Docker image configuration for GitHub Actions

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -172,6 +172,10 @@ jobs:
           ENV ARCH=${{ matrix.arch }} \
               DEBIAN_FRONTEND=noninteractive
 
+          # Create docker group and armbian user early (before package installations)
+          RUN groupadd docker && \
+              useradd -m -s /bin/bash armbian
+
           # Install essential packages
           RUN apt-get update && apt-get install -y \
               wget \
@@ -246,11 +250,9 @@ jobs:
               apt-get update && \
               rm -rf /var/lib/apt/lists/*
 
-          # Create armbian user with Docker and sudo permissions
-          RUN groupadd docker 2>/dev/null || true && \
-              useradd -m -s /bin/bash armbian && \
-              usermod -aG docker armbian && \
-              echo "armbian ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/armbian && \
+          # Add armbian to docker group and configure sudo
+          RUN usermod -aG docker armbian && \
+              echo "armbian ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/armbian && \
               chmod 0440 /etc/sudoers.d/armbian
 
           # Set default user

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -247,7 +247,8 @@ jobs:
               rm -rf /var/lib/apt/lists/*
 
           # Create armbian user with Docker and sudo permissions
-          RUN useradd -m -s /bin/bash armbian && \
+          RUN groupadd docker 2>/dev/null || true && \
+              useradd -m -s /bin/bash armbian && \
               usermod -aG docker armbian && \
               echo "armbian ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/armbian && \
               chmod 0440 /etc/sudoers.d/armbian

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -240,7 +240,17 @@ jobs:
               apt-get update && \
               rm -rf /var/lib/apt/lists/*
 
-          WORKDIR /workspace
+          # Create armbian user with Docker and sudo permissions
+          RUN useradd -m -s /bin/bash armbian && \
+              usermod -aG docker armbian && \
+              echo "armbian ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/armbian && \
+              chmod 0440 /etc/sudoers.d/armbian
+
+          # Set default user
+          USER armbian
+          ENV HOME=/home/armbian
+          WORKDIR /home/armbian/workspace
+
           CMD ["/bin/bash"]
           DOCKEREOF
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -41,14 +41,20 @@ jobs:
           for dist_file in armbian-build/config/distributions/*/support; do
             [ -f "$dist_file" ] || continue
 
+            dist_dir=$(dirname "$dist_file")
+            release=$(basename "$dist_dir")
+
             # Skip distribution if marked as EOS (End of Service)
             if grep -qi "eos" "$dist_file"; then
-              echo "::debug::Skipping $(basename $(dirname $dist_file)) - marked as EOS"
+              echo "::debug::Skipping $release - marked as EOS"
               continue
             fi
 
-            dist_dir=$(dirname "$dist_file")
-            release=$(basename "$dist_dir")
+            # Skip manually disabled releases
+            if [[ "$release" == "sid" ]] || [[ "$release" == "forky" ]]; then
+              echo "::notice::Skipping $release - manually disabled"
+              continue
+            fi
 
             # Get distribution name and family
             dist_name_file="$dist_dir/name"

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -191,6 +191,7 @@ jobs:
               curl \
               jq \
               sudo \
+              expect \
               lsb-release \
               iproute2 \
               figlet \

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -176,10 +176,6 @@ jobs:
           RUN groupadd docker && \
               useradd -m -s /bin/bash armbian
 
-          # Create GitHub Actions workspace directory with proper permissions
-          RUN mkdir -p /__w && \
-              chmod 1777 /__w
-
           # Install essential packages
           RUN apt-get update && apt-get install -y \
               wget \
@@ -259,10 +255,9 @@ jobs:
               echo "armbian ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/armbian && \
               chmod 0440 /etc/sudoers.d/armbian
 
-          # Set default user
-          USER armbian
-          ENV HOME=/home/armbian
-          WORKDIR /home/armbian/workspace
+          # NOTE: Don't set USER here. Running as root allows GitHub Actions to work properly.
+          # The workflow can switch to 'armbian' user when needed using: su - armbian -c 'command'
+          WORKDIR /workspace
 
           CMD ["/bin/bash"]
           DOCKEREOF

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -236,7 +236,7 @@ jobs:
           # Add Armbian stable repository
           RUN curl -fsSL http://apt.armbian.com/armbian.key | gpg --dearmor -o /usr/share/keyrings/armbian-archive-keyring.gpg && \
               chmod go+r /usr/share/keyrings/armbian-archive-keyring.gpg && \
-              echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/armbian-archive-keyring.gpg] http://apt.armbian.com bookworm main" > /etc/apt/sources.list.d/armbian.list && \
+              echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/armbian-archive-keyring.gpg] http://apt.armbian.com ${{ matrix.release }} main" > /etc/apt/sources.list.d/armbian.list && \
               apt-get update && \
               rm -rf /var/lib/apt/lists/*
 
@@ -268,55 +268,34 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: Checkout Armbian build framework
-        uses: actions/checkout@v4
-        with:
-          repository: armbian/build
-          ref: main
-          path: armbian-build
-
-      - name: Generate summary
+      - name: Generate summary from matrix
         run: |
           echo '# Docker Images Built' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
-          echo '| Release | Arch | Image |' >> $GITHUB_STEP_SUMMARY
-          echo '|---------|------|-------|' >> $GITHUB_STEP_SUMMARY
+          echo '| Release | Arch | Platform | Image |' >> $GITHUB_STEP_SUMMARY
+          echo '|---------|------|----------|-------|' >> $GITHUB_STEP_SUMMARY
 
-          # Process each distribution
-          for dist_file in armbian-build/config/distributions/*/support; do
-            [ -f "$dist_file" ] || continue
+          # Parse images from setup-matrix output
+          images="${{ needs.setup-matrix.outputs.images }}"
+          if [ -n "$images" ]; then
+            IFS=', ' read -ra IMAGE_ARRAY <<< "$images"
+            for img in "${IMAGE_ARRAY[@]}"; do
+              # Parse "release-arch" format
+              release="${img%-*}"
+              arch="${img#*-}"
 
-            # Skip distribution if marked as EOS (End of Service)
-            if grep -qi "eos" "$dist_file"; then
-              continue
-            fi
+              # Determine platform
+              case "$arch" in
+                amd64) platform="linux/amd64" ;;
+                arm64) platform="linux/arm64" ;;
+                *) platform="unknown" ;;
+              esac
 
-            dist_dir=$(dirname "$dist_file")
-            release=$(basename "$dist_dir")
-
-            # Get distribution name and family
-            dist_name_file="$dist_dir/name"
-            if [ ! -f "$dist_name_file" ]; then
-              continue
-            fi
-
-            # Get architectures file
-            arch_file="$dist_dir/architectures"
-            if [ ! -f "$arch_file" ]; then
-              continue
-            fi
-
-            # Read architectures (comma-separated on one line or one per line)
-            arch_list=$(cat "$arch_file" | tr -d ' \n' | tr ',' ' ')
-            for arch in $arch_list; do
-              # Skip comments and empty lines
-              [[ "$arch" =~ ^#.*$ ]] && continue
-              [ -z "$arch" ] && continue
-
-              image="repository-update:${release}-${arch}"
-              echo "| $release | $arch | $image |" >> $GITHUB_STEP_SUMMARY
+              echo "| $release | $arch | $platform | ${{ env.REGISTRY }}/repository-update:$img |" >> $GITHUB_STEP_SUMMARY
             done
-          done
+          else
+            echo "| No images built | | |" >> $GITHUB_STEP_SUMMARY
+          fi
 
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '✅ Images pushed to GitHub Container Registry' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -191,13 +191,11 @@ jobs:
               curl \
               jq \
               sudo \
-              dialog \
               lsb-release \
               iproute2 \
               figlet \
               pv \
               tree \
-              whiptail \
               systemd-sysv \
               containerd \
               iptables \

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -176,6 +176,10 @@ jobs:
           RUN groupadd docker && \
               useradd -m -s /bin/bash armbian
 
+          # Create GitHub Actions workspace directory with proper permissions
+          RUN mkdir -p /__w && \
+              chmod 1777 /__w
+
           # Install essential packages
           RUN apt-get update && apt-get install -y \
               wget \


### PR DESCRIPTION
## Summary
- Remove `dialog` and `whiptail` packages from Docker images
- Move armbian user creation before package installations  
- Fix permissions for GitHub Actions workspace (`/__w`)
- Remove default USER instruction to allow running as root
- Add dynamic release and architecture matrix generation

## Details

### Non-interactive mode support
The tool runs non-interactively in GitHub Actions, so dialog tools are unnecessary. Their absence ensures `DIALOG` is set to 'read' mode automatically.

### User and permissions fixes
- Create docker group and armbian user before installing packages (fixes useradd conflicts)
- Create `/__w` directory with world-writable permissions for GitHub Actions workspace
- Removed `USER armbian` instruction - GitHub Actions need root access

### Matrix generation improvements
- Dynamic matrix generation from Armbian build framework distribution configs
- Filter EOS (End of Service) releases
- Manual filter for sid and forky releases
- Improved summary job

## Test plan
- [x] Docker images build successfully
- [x] Unit tests pass with TERM=linux
- [x] No dialog/whiptail dependencies