### PR TITLE
ci: build repository-update images for riscv64

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -102,7 +102,10 @@ jobs:
                 arm64)
                   docker_platform="linux/arm64"
                   ;;
-                armhf|riscv64)
+                riscv64)
+                  docker_platform="linux/riscv64"
+                  ;;
+                armhf)
                   echo "::debug::Skipping $arch - fragile. Will use in the future or drop entirely"
                   continue
                   ;;
@@ -206,21 +209,28 @@ jobs:
               udev \
               && rm -rf /var/lib/apt/lists/*
 
-          # Install Aptly from GitHub releases
+          # Install Aptly. aptly-dev publishes Linux binaries for amd64,
+          # arm64 and armhf (named 'arm'); riscv64 has no upstream
+          # release — fall back to the distro's aptly package there.
           RUN APTLY_VERSION="1.6.2" && \
-              if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-                APTLY_ARCH="amd64"; \
-              elif [ "$(dpkg --print-architecture)" = "arm64" ]; then \
-                APTLY_ARCH="arm64"; \
-              elif [ "$(dpkg --print-architecture)" = "armhf" ]; then \
-                APTLY_ARCH="arm"; \
+              DEB_ARCH="$(dpkg --print-architecture)" && \
+              case "$DEB_ARCH" in \
+                amd64)  APTLY_ARCH="amd64" ;; \
+                arm64)  APTLY_ARCH="arm64" ;; \
+                armhf)  APTLY_ARCH="arm"   ;; \
+                *)      APTLY_ARCH=""      ;; \
+              esac && \
+              if [ -n "$APTLY_ARCH" ]; then \
+                wget -q https://github.com/aptly-dev/aptly/releases/download/v${APTLY_VERSION}/aptly_${APTLY_VERSION}_linux_${APTLY_ARCH}.zip && \
+                unzip -q aptly_${APTLY_VERSION}_linux_${APTLY_ARCH}.zip && \
+                mv aptly_${APTLY_VERSION}_linux_${APTLY_ARCH}/aptly /usr/local/bin/ && \
+                rm -rf aptly_${APTLY_VERSION}_linux_${APTLY_ARCH} \
+                       aptly_${APTLY_VERSION}_linux_${APTLY_ARCH}.zip; \
               else \
-                APTLY_ARCH="$(dpkg --print-architecture)"; \
+                apt-get update && \
+                apt-get install -y aptly && \
+                rm -rf /var/lib/apt/lists/*; \
               fi && \
-              wget -q https://github.com/aptly-dev/aptly/releases/download/v${APTLY_VERSION}/aptly_${APTLY_VERSION}_linux_${APTLY_ARCH}.zip && \
-              unzip -q aptly_${APTLY_VERSION}_linux_${APTLY_ARCH}.zip && \
-              mv aptly_${APTLY_VERSION}_linux_${APTLY_ARCH}/aptly /usr/local/bin/ && \
-              rm -f aptly_${APTLY_VERSION}_linux_${APTLY_ARCH}.zip \
               aptly version
 
           # Install appropriate keyring based on container type
@@ -304,9 +314,10 @@ jobs:
 
               # Determine platform
               case "$arch" in
-                amd64) platform="linux/amd64" ;;
-                arm64) platform="linux/arm64" ;;
-                *) platform="unknown" ;;
+                amd64)   platform="linux/amd64"   ;;
+                arm64)   platform="linux/arm64"   ;;
+                riscv64) platform="linux/riscv64" ;;
+                *)       platform="unknown"       ;;
               esac
 
               echo "| $release | $arch | $platform | ${{ env.REGISTRY }}/repository-update:$img |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Extends the nightly `Docker Images For Repo Handling` build matrix to cover `linux/riscv64` alongside `linux/amd64` and `linux/arm64`. After this, every non-EOS release's `architectures` file that lists `riscv64` will get a corresponding `ghcr.io/armbian/repository-update:<release>-riscv64` tag published.

### What changed

- **Matrix**: `arch=riscv64` maps to `docker_platform=linux/riscv64` (previously grouped with armhf under the 'fragile' skip). armhf stays skipped — separate decision.
- **Dockerfile (aptly install)**: aptly-dev doesn't publish a `linux/riscv64` release binary. For arches with an upstream binary (amd64/arm64/armhf=arm) we keep the existing GitHub-download path; riscv64 (and any future binary-less arch) falls back to the distro's `aptly` package via `apt install aptly`. CLI surface is stable across aptly's recent releases so the two paths are interchangeable for our consumers.
- **Summary table**: recognises riscv64 so it renders `linux/riscv64` instead of `unknown`.

### Runner / emulation

No runner-pool change: `docker/setup-qemu-action@v3` + `buildx` is already wired in and supports emulated `linux/riscv64` builds from the amd64 runner. Builds will be slower (qemu-user emulation) but published images are native riscv64 manifests.