### PR TITLE
ci: add dependabot config (github-actions, daily)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Keep the actions used by the two nightly image-build workflows fresh.
+  # There are no Dockerfiles or language manifests in this repo (the
+  # image Dockerfile is generated inline in build-docker-images.yml),
+  # so GitHub Actions is the only ecosystem to track here.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to keep the actions pinned by the two nightly workflows (`build-docker-images.yml`, `update_docker.yml`) up to date.

- Ecosystem: `github-actions` only — there are no Dockerfiles or language manifests in this repo (the image Dockerfile is generated inline by `build-docker-images.yml`).
- Interval: daily — CI here pushes images to ghcr.io with write permissions on both repo contents and packages, so action bumps (especially security-sensitive ones like `docker/build-push-action`, `docker/login-action`) should land quickly.
- PRs get the `dependencies` + `github-actions` labels and commit-message prefix `ci` with scope.