### PR TITLE
ci: build repository-update images for armhf

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -106,8 +106,7 @@ jobs:
                   docker_platform="linux/riscv64"
                   ;;
                 armhf)
-                  echo "::debug::Skipping $arch - fragile. Will use in the future or drop entirely"
-                  continue
+                  docker_platform="linux/arm/v7"
                   ;;
                 *)
                   echo "::warning::Unknown architecture $arch, skipping"
@@ -316,6 +315,7 @@ jobs:
               case "$arch" in
                 amd64)   platform="linux/amd64"   ;;
                 arm64)   platform="linux/arm64"   ;;
+                armhf)   platform="linux/arm/v7"  ;;
                 riscv64) platform="linux/riscv64" ;;
                 *)       platform="unknown"       ;;
               esac


### PR DESCRIPTION
Follow-up to [#15](https://github.com/armbian/docker-armbian-build/pull/15). armhf was still skipped in the setup-matrix step with a `::debug::Skipping` — 'fragile, will use in the future or drop entirely'.

Enabling it now unblocks the emulated-matrix path I just shipped in configng ([configng#875](https://github.com/armbian/configng/pull/875)), which lets a test opt into armhf coverage via `TESTARCH` and expects `ghcr.io/armbian/repository-update:<release>-armhf` tags to exist.

### Changes

- **matrix case**: `armhf → docker_platform=linux/arm/v7`
- **summary table**: `armhf → linux/arm/v7` (was rendering as 'unknown')

### No other changes needed

- **Aptly install** already handles armhf: the riscv64 PR's case statement maps `armhf → APTLY_ARCH="arm"` and wgets the upstream release binary named `aptly__linux_arm.zip` (aptly-dev publishes that).
- **Runner pool** unchanged: `docker/setup-qemu-action@v3` + buildx on `ubuntu-latest` (amd64) already cross-builds `linux/arm/v7` under emulation.

### Effect on next nightly rebuild

Every non-EOS release whose `config/distributions/<release>/architectures` declares `armhf` will start getting a `<release>-armhf` tag published.