### PR TITLE
ci: add Maintenance: Watchdog workflow

### DIFF
--- a/.github/workflows/maintenance-watchdog.yml
+++ b/.github/workflows/maintenance-watchdog.yml
@@ -1,0 +1,69 @@
+name: "Maintenance: Watchdog"
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+concurrency:
+  group: watchdog-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  watchdog:
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+
+        # list scripts you want to watch and execute failed jobs x-times
+        script:
+          - build-docker-images
+          - update_docker
+
+    name: "${{ matrix.script }}"
+    runs-on: ubuntu-24.04
+    if: ${{ github.repository_owner == 'Armbian' }}
+    steps:
+
+      - name: "Restart ${{ matrix.script }}.yml"
+        run: |
+          set -euo pipefail
+
+          # Define variables here
+          ATTEMPTS="3"
+          SCRIPT="${{ matrix.script }}"
+
+          # Get workflow ID
+          WORKFLOW=$(gh api "/repos/${{ github.repository }}/actions/workflows" | jq -r --arg path ".github/workflows/${SCRIPT}.yml" '.workflows[] | select(.path==$path) | .id')
+
+          if [ -z "$WORKFLOW" ]; then
+            echo "Error: Workflow ${SCRIPT}.yml not found"
+            exit 1
+          fi
+
+          # Get the most recent workflow run (sorted by created, descending)
+          RUN_DATA=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW}/runs?per_page=1" | jq '.workflow_runs[0] | {id: .id, conclusion: .conclusion, attempt: .run_attempt}')
+
+          ID=$(echo "$RUN_DATA" | jq -r '.id')
+          STATUS=$(echo "$RUN_DATA" | jq -r '.conclusion')
+          ATTEMPT=$(echo "$RUN_DATA" | jq -r '.attempt')
+
+          if [ -z "$ID" ] || [ "$ID" == "null" ]; then
+            echo "No workflow runs found for ${SCRIPT}.yml"
+            exit 0
+          fi
+
+          # if attempt is lower than 3 and status is "failure", rerun failed jobs
+          if [ "${ATTEMPT}" -lt "${ATTEMPTS}" ] && [ "$STATUS" == "failure" ]; then
+            echo "Rerunning failed jobs for ${SCRIPT}.yml (attempt ${ATTEMPT}/${ATTEMPTS}, status: ${STATUS})"
+            gh api --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/repos/${{ github.repository }}/actions/runs/${ID}/rerun-failed-jobs"
+          else
+            echo "No rerun needed for ${SCRIPT}.yml (attempt ${ATTEMPT}/${ATTEMPTS}, status: ${STATUS})"
+          fi


### PR DESCRIPTION
## Summary

Mirrors the **Maintenance: Watchdog** workflow we already use in [armbian.github.io](https://github.com/armbian/armbian.github.io/blob/main/.github/workflows/maintenance-watchdog.yml).

Runs every 15 minutes (and on \`workflow_dispatch\`), iterates over a matrix of workflow basenames, and re-runs failed jobs on the most recent run up to 3 attempts via \`POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs\`. Anything past attempt 3 is left alone.

## Watched workflows

- \`build-docker-images\` — daily *Docker Images For Repo Handling*
- \`update_docker\` — *Docker Images for Framework*

Catches transient registry / network / runner blips during the nightly image refresh without anyone having to click *Re-run failed jobs*. Restricted to the Armbian org via \`if: github.repository_owner == 'Armbian'\` so forks don't accidentally re-run themselves.

## Test plan

- [ ] After merge, confirm the workflow appears under Actions and the next \`*/15\` cron tick runs cleanly.
- [ ] If a watched workflow has a recent \`failure\` conclusion with attempt < 3, confirm the watchdog kicks off a re-run.