### PR TITLE
ci: rename build workflow to 'Docker Images For Automation'

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,4 +1,4 @@
-name: Docker Images For Repo Handling
+name: Docker Images For Automation
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary

Cosmetic rename of the workflow's display name in the Actions UI — historical name no longer described what the workflow actually does.

- **Before:** Docker Images For Repo Handling
- **After:** Docker Images For Automation

Filename (\`build-docker-images.yml\`) is unchanged, so existing schedules, references, and the watchdog matrix in #23 keep working.