### PR TITLE
README: cover both image families this repo publishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,7 @@
 
 ### Purpose of This Repository
 
-Build and publish Docker images for the [Armbian Build Framework](https://github.com/armbian/build) to support isolated, reproducible, and architecture-independent builds. Images are tagged and pushed to the [GitHub Container Registry](https://github.com/orgs/armbian/packages) for use in CI pipelines, local development, and automation environments.
+Build and publish Docker images used across Armbian's automation, pushed to the [GitHub Container Registry](https://github.com/orgs/armbian/packages):
+
+- **Build-framework images** for [`armbian/build`](https://github.com/armbian/build) — isolated, reproducible, architecture-independent build environments consumed by `./compile.sh docker …` in CI and local development.
+- **Repository-automation images** for the internal package-publishing pipeline (aptly and supporting tooling), with the supported-release matrix tracking `armbian/build` automatically.


### PR DESCRIPTION
## Summary

The previous one-line description only mentioned the build-framework images consumed by `./compile.sh docker …`. This repo also publishes a second, distinct image family — **repository-automation images** for the internal package-publishing pipeline (aptly + tooling) — driven by a matrix that tracks `armbian/build`'s supported releases automatically.

Kept the description tight: same logo header, same H3, just expand the single paragraph into two bullets so newcomers see both purposes without scrolling.