### PR TITLE
framework: add resolute (Ubuntu 26.04) image to the daily matrix

### DIFF
--- a/.github/workflows/update_docker.yml
+++ b/.github/workflows/update_docker.yml
@@ -31,6 +31,8 @@ jobs:
           - { os: "debian", release: "trixie", arch: "arm64", runner: "ubuntu-24.04-arm" }
           - { os: "ubuntu", release: "noble", arch: "amd64", runner: "ubuntu-24.04" }
           - { os: "ubuntu", release: "noble", arch: "arm64", runner: "ubuntu-24.04-arm" }
+          - { os: "ubuntu", release: "resolute", arch: "amd64", runner: "ubuntu-24.04" }
+          - { os: "ubuntu", release: "resolute", arch: "arm64", runner: "ubuntu-24.04-arm" }
     runs-on: "${{ matrix.runner }}"
     name: "${{ matrix.release }} ${{ matrix.arch }} (${{ matrix.os }})"
     env:
@@ -182,6 +184,14 @@ jobs:
             ghcr.io/${{ github.repository }}:armbian-ubuntu-noble-amd64-latest \
             ghcr.io/${{ github.repository }}:armbian-ubuntu-noble-arm64-latest
           docker buildx imagetools inspect ghcr.io/${{ github.repository }}:armbian-ubuntu-noble-latest
+
+      - name: ubuntu-resolute - Create and push multi-arch manifest using buildx
+        run: |
+          docker buildx imagetools create -t \
+            ghcr.io/${{ github.repository }}:armbian-ubuntu-resolute-latest \
+            ghcr.io/${{ github.repository }}:armbian-ubuntu-resolute-amd64-latest \
+            ghcr.io/${{ github.repository }}:armbian-ubuntu-resolute-arm64-latest
+          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:armbian-ubuntu-resolute-latest
 
   keepalive:
     if: ${{ github.repository_owner == 'armbian' }}


### PR DESCRIPTION
## Summary

Adds **resolute** (Ubuntu 26.04) to [`.github/workflows/update_docker.yml`](.github/workflows/update_docker.yml) — the daily *Docker Images for Framework* workflow that publishes the per-release build environments consumed by `armbian/build`'s `./compile.sh docker …`.

After this lands, `armbian/build` users can target resolute end-to-end without first having to build the framework image locally.

## Changes

- `docker-per-arch` matrix gains `ubuntu/resolute/amd64` and `ubuntu/resolute/arm64`, mirroring the noble rows (same `ubuntu-24.04` / `ubuntu-24.04-arm` runners — buildx + QEMU does the heavy lifting, the host kernel doesn't drive the resulting image).
- `join-arches` gains a corresponding multi-arch manifest step:
  - `armbian-ubuntu-resolute-amd64-latest` + `armbian-ubuntu-resolute-arm64-latest` → `armbian-ubuntu-resolute-latest`.

## Why now

`armbian/build`'s `config/distributions/resolute/support` is already `supported` (alongside `noble` and `trixie`); the rest of the toolchain (release-targets generators, board matrices, etc.) tracks resolute as an active Ubuntu release for nightly + community + standard scopes.

## Dependency

The first run on this branch hit `E: Package 'qemu-user-static' has no installation candidate` on resolute — that package is virtual on Ubuntu 26.04. Fixed in [armbian/build#9790](https://github.com/armbian/build/pull/9790); needs to land before this PR's matrix can go green.

## Test plan

- [ ] After [armbian/build#9790](https://github.com/armbian/build/pull/9790) merges, next scheduled run (or workflow_dispatch) produces:
  - `ghcr.io/armbian/docker-armbian-build:armbian-ubuntu-resolute-amd64-latest`
  - `ghcr.io/armbian/docker-armbian-build:armbian-ubuntu-resolute-arm64-latest`
  - the joined `armbian-ubuntu-resolute-latest` multi-arch tag.
- [ ] No regressions on jammy / bookworm / trixie / noble images.
- [ ] `armbian/build` `./compile.sh docker` with `RELEASE=resolute` pulls and runs the new image cleanly.