### PR TITLE
ci: build current apt-cacher-ng image (trixie/3.7.x)

### DIFF
--- a/.github/workflows/build-apt-cacher-ng.yml
+++ b/.github/workflows/build-apt-cacher-ng.yml
@@ -1,0 +1,91 @@
+name: apt-cacher-ng Image
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/build-apt-cacher-ng.yml'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1' # Weekly, Monday 04:00 UTC — pick up trixie point/security updates
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io/${{ github.repository_owner }}
+
+jobs:
+  build:
+    name: "Build apt-cacher-ng (trixie)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Dockerfile
+        run: |
+          cat > Dockerfile <<'DOCKEREOF'
+          # Current apt-cacher-ng from Debian trixie (3.7.x) — the classical
+          # multi-repo caching apt proxy. Replaces the abandoned 2020
+          # sameersbn/apt-cacher-ng:3.3 image with ~4 years of reliability
+          # fixes (index handling, concurrency, HTTPS remapping).
+          FROM debian:trixie-slim
+
+          ENV DEBIAN_FRONTEND=noninteractive
+
+          RUN apt-get update && \
+              apt-get install -y --no-install-recommends \
+                apt-cacher-ng \
+                ca-certificates && \
+              rm -rf /var/lib/apt/lists/*
+
+          # Override config: cache on a bind-mountable volume, run in the
+          # foreground (PID 1), allow HTTPS repos via CONNECT tunneling, and
+          # never expire cached packages (host has plenty of disk).
+          RUN printf '%s\n' \
+                'CacheDir: /var/cache/apt-cacher-ng' \
+                'LogDir: /var/log/apt-cacher-ng' \
+                'ForeGround: 1' \
+                'PassThroughPattern: .*' \
+                'ExThreshold: 0' \
+                'VerboseLog: 0' \
+                > /etc/apt-cacher-ng/zzz_armbian.conf
+
+          VOLUME ["/var/cache/apt-cacher-ng"]
+          EXPOSE 3142
+
+          CMD ["/usr/sbin/apt-cacher-ng", "-c", "/etc/apt-cacher-ng"]
+          DOCKEREOF
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.REGISTRY }}/apt-cacher-ng:latest
+            ${{ env.REGISTRY }}/apt-cacher-ng:trixie
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          load: false
+
+      - name: Image built
+        run: |
+          echo "::notice::Built and pushed ${{ env.REGISTRY }}/apt-cacher-ng:latest (linux/amd64, linux/arm64)"
+          echo '# apt-cacher-ng image' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo "Pushed \`${{ env.REGISTRY }}/apt-cacher-ng:latest\` and \`:trixie\` (linux/amd64, linux/arm64) ✅" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

The only public apt-cacher-ng image, `sameersbn/apt-cacher-ng:3.3-20200524`, is **abandoned** (last push >1 year ago, version 3.3 from 2020) and unreliable under concurrent build-farm load — stale/corrupt index files, 503s, broken HTTPS repos.

This adds a workflow that builds our own image from `debian:trixie-slim` (apt-cacher-ng **3.7.x**, ~4 years of fixes) and publishes it to `ghcr.io/armbian/apt-cacher-ng` for the configng `module_aptcacherng` to pull.

## Details

- **Multi-arch:** `linux/amd64, linux/arm64` (single manifest via buildx), matching the configng module's declared arches
- **Config override** (`zzz_armbian.conf`) tuned for a LAN cache:
  - `PassThroughPattern: .*` — HTTPS repos via CONNECT tunneling
  - `ExThreshold: 0` — never expire cached packages (plenty of disk)
  - cache on a bind-mountable volume, runs foreground as PID 1
- **Tags:** `:latest` and `:trixie`
- **Triggers:** push (workflow changes), manual dispatch, and weekly (Mon 04:00 UTC) to pick up trixie point/security updates

Follows the existing `build-docker-images.yml` conventions (buildx + `docker/build-push-action`, `ghcr.io/${owner}`).

> Note: `PassThroughPattern: .*` makes it an open CONNECT proxy — intended for a trusted LAN build farm, not internet exposure.

Companion configng change (module swap to pull this image) follows.