### PR TITLE
README: document full image catalog (framework, automation, caching proxies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,20 @@
 
 ### Purpose of This Repository
 
-Build and publish Docker images used across Armbian's automation, pushed to the [GitHub Container Registry](https://github.com/orgs/armbian/packages):
+Build and publish the Docker images used across Armbian's automation and infrastructure, pushed to the [GitHub Container Registry](https://github.com/orgs/armbian/packages). Each image is produced by its own GitHub Actions workflow on a schedule (and on demand via *Run workflow*).
 
-- **Build-framework images** for [`armbian/build`](https://github.com/armbian/build) — isolated, reproducible, architecture-independent build environments consumed by `./compile.sh docker …` in CI and local development.
-- **Repository-automation images** for the internal package-publishing pipeline (aptly and supporting tooling), with the supported-release matrix tracking `armbian/build` automatically.
+### Published images
+
+- **`ghcr.io/armbian/docker-armbian-build:armbian-<os>-<release>-<arch>-latest`** ([`update_docker.yml`](.github/workflows/update_docker.yml)) — [`armbian/build`](https://github.com/armbian/build) `./compile.sh docker …` build environments.
+- **`ghcr.io/armbian/repository-update:<release>-<arch>`** ([`build-docker-images.yml`](.github/workflows/build-docker-images.yml)) — internal package-publishing pipeline (aptly).
+- **`ghcr.io/armbian/apt-cacher-ng:latest`** (`:trixie`) ([`build-apt-cacher-ng.yml`](.github/workflows/build-apt-cacher-ng.yml)) — `armbian-config` → `module_aptcacherng`, apt caching proxy.
+- **`ghcr.io/armbian/git_cdn:latest`** ([`build-git-cdn.yml`](.github/workflows/build-git-cdn.yml)) — `armbian-config` → `module_git_cdn`, git+http caching proxy.
+
+The build-framework and automation matrices are generated from the supported-release list in `armbian/build`, so they track upstream automatically.
+
+### Maintenance
+
+- [`maintenance-watchdog.yml`](.github/workflows/maintenance-watchdog.yml) — runs every 15 minutes and re-runs failed jobs for the daily `build-docker-images` and `update_docker` workflows, so a transient registry or network error self-heals without manual intervention.
+- [`dependabot.yml`](.github/dependabot.yml) — keeps the workflows' GitHub Actions dependencies up to date.
+
+> All images are multi-arch (`linux/amd64` + `linux/arm64`) built with Docker Buildx + QEMU. Dockerfiles are generated at build time inside each workflow rather than committed to this repository.


### PR DESCRIPTION
The README described only the build-framework and automation images in prose, naming no workflows or image tags. The repo also publishes the **apt-cacher-ng** and **git_cdn** caching images and runs a **maintenance watchdog** — none of which were mentioned.

Rewrites the README so every published image is listed (minimal — tag, workflow, consumer):

- `docker-armbian-build:armbian-<os>-<release>-<arch>-latest` (`update_docker.yml`) — `armbian/build` `./compile.sh docker` build environments
- `repository-update:<release>-<arch>` (`build-docker-images.yml`) — aptly package-publishing pipeline
- `apt-cacher-ng:latest`, `:trixie` (`build-apt-cacher-ng.yml`) — configng `module_aptcacherng`
- `git_cdn:latest` (`build-git-cdn.yml`) — configng `module_git_cdn`

Plus a Maintenance section (watchdog + dependabot) and a note that all images are multi-arch with build-time-generated Dockerfiles.

Also done outside this PR: expanded the repo About description and added the `caching-proxy` topic.